### PR TITLE
Publish CLI binary when create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set APP_VERSION env
-      run: echo ::set-env name=APP_VERSION::$(basename ${GITHUB_REF})
-    - name: Set BUILD_TIME env
-      run: echo ::set-env name=BUILD_TIME::$(date)
-    - name: Environment Printer
-      uses: managedkaos/print-env@v1.0
-
     - uses: wangyoucao577/go-release-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +23,6 @@ jobs:
         goversion: "https://golang.org/dl/go1.15.3.linux-amd64.tar.gz"
         project_path: "./"
         binary_name: gnostic-grpc
-        build_flags: -v
 
         
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release Go Binaries
+
+on: 
+  release:
+    types: [created]
+
+jobs:
+  releases-matrix:
+    name: gnostic-grpc
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set APP_VERSION env
+      run: echo ::set-env name=APP_VERSION::$(basename ${GITHUB_REF})
+    - name: Set BUILD_TIME env
+      run: echo ::set-env name=BUILD_TIME::$(date)
+    - name: Environment Printer
+      uses: managedkaos/print-env@v1.0
+
+    - uses: wangyoucao577/go-release-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: "https://golang.org/dl/go1.15.3.linux-amd64.tar.gz"
+        project_path: "./"
+        binary_name: gnostic-grpc
+        build_flags: -v
+
+        
+


### PR DESCRIPTION
So that people don't need to install `Go` in their local.          

For example: https://github.com/wangyoucao577/gnostic-grpc/releases/tag/v0.1.2-testonly

After merge this PR, you can            
- Create a release      
- Wait a few minutes, then you'll see the binaries automatically published to this release.      

Consumer usage example:       
```bash
$ wget https://github.com/wangyoucao577/gnostic-grpc/releases/download/v0.1.2-testonly/gnostic-grpc-v0.1.2-testonly-linux-amd64.tar.gz && tar -zxf gnostic-grpc-v0.1.2-testonly-linux-amd64.tar.gz && rm gnostic-grpc-v0.1.2-testonly-linux-amd64.tar.gz
$ wget https://github.com/wangyoucao577/gnostic/releases/download/v0.5.3-testonly/gnostic-v0.5.3-testonly-linux-amd64.tar.gz && tar -zxf gnostic-v0.5.3-testonly-linux-amd64.tar.gz && rm gnostic-v0.5.3-testonly-linux-amd64.tar.gz
$ ls -lh
total 31M
-rwxr-xr-x 1 mapuser appuser  15M Nov  5 22:58 gnostic
-rwxr-xr-x 1 mapuser appuser  16M Nov  5 22:58 gnostic-grpc
-rw-r--r-- 1 mapuser appuser  14K Nov  5 22:31 v9.yaml
$ PATH=$(pwd):$PATH ./gnostic --grpc-out=./ ./v9.yaml
# Enjoy! 
```